### PR TITLE
Update event list to display start and end times

### DIFF
--- a/app/controllers/discourse_post_event/events_controller.rb
+++ b/app/controllers/discourse_post_event/events_controller.rb
@@ -120,6 +120,7 @@ module DiscoursePostEvent
         :include_expired,
         :limit,
         :before,
+        :include_start_end_times
       )
     end
   end

--- a/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -117,6 +117,13 @@ export default class UpcomingEventsList extends Component {
   }
 
   @action
+  formatDateRange({ starts_at, ends_at }) {
+    const startDate = moment(starts_at).format("LLL");
+    const endDate = ends_at ? moment(ends_at).format("LLL") : null;
+    return endDate ? `${startDate} - ${endDate}` : startDate;
+  }
+
+  @action
   startsAtMonth(month, day) {
     return moment(`${month}-${day}`).format("MMM");
   }
@@ -200,6 +207,9 @@ export default class UpcomingEventsList extends Component {
                           {{this.formatTime event}}
                         </span>
                       {{/if}}
+                      <span class="upcoming-events-list__event-date-range">
+                        {{this.formatDateRange event}}
+                      </span>
                     </div>
                   </a>
                 {{/each}}


### PR DESCRIPTION
Update the calendar to display events with a start and end time as a list with clear start and end times.

* **Upcoming Events List Component**
  - Add `formatDateRange` action to format events as a list with clear start and end times.
  - Update template to display start and end times for each event.

* **Events Controller**
  - Add `include_start_end_times` parameter to fetch events with start and end times for the list view.

